### PR TITLE
fix `updateMenu(null)` not working

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "custom-electron-titlebar",
-  "version": "4.1.2",
+  "version": "4.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "custom-electron-titlebar",
-      "version": "4.1.2",
+      "version": "4.1.5",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.20.2",

--- a/src/titlebar.ts
+++ b/src/titlebar.ts
@@ -158,9 +158,9 @@ export default class Titlebar {
 	}
 
 	_loadEvents() {
-		ipcRenderer.on('window-maximize', (_, isMaximized: boolean) => this._onDidChangeMaximized(isMaximized));
-		ipcRenderer.on('window-fullscreen', (_, isFullScreen: boolean) => this.onWindowFullScreen(isFullScreen));
-		ipcRenderer.on('window-focus', (_, isFocused: boolean) => this.onWindowFocus(isFocused));
+		ipcRenderer.on('window-maximize', (_: any, isMaximized: boolean) => this._onDidChangeMaximized(isMaximized));
+		ipcRenderer.on('window-fullscreen', (_: any, isFullScreen: boolean) => this.onWindowFullScreen(isFullScreen));
+		ipcRenderer.on('window-focus', (_: any, isFocused: boolean) => this.onWindowFocus(isFocused));
 
 		if (this._options.minimizable) addDisposableListener(this._windowControlIcons.minimize, EventType.CLICK, () => {
 			ipcRenderer.send('window-event', 'window-minimize');
@@ -214,7 +214,7 @@ export default class Titlebar {
 		if (this._options.menu) {
 			this.updateMenu(this._options.menu);
 		} else if (this._options.menu !== null) {
-			ipcRenderer.invoke('request-application-menu').then(menu => this.updateMenu(menu));
+			ipcRenderer.invoke('request-application-menu').then((menu: Menu) => this.updateMenu(menu));
 		}
 
 		if (this._options.menuPosition) {
@@ -429,7 +429,9 @@ export default class Titlebar {
 	public updateMenu(menu: Menu): Titlebar {
 		if (!isMacintosh) {
 			if (this._menubar) this._menubar.dispose();
-			if (menu) this._options.menu = menu;
+			if (!menu) return this;
+
+			this._options.menu = menu;
 
 			this._menubar = new Menubar(this._menubarContainer, this._options, this._closeMenu);
 			this._menubar.setupMenubar();
@@ -447,7 +449,7 @@ export default class Titlebar {
 	 * Update the menu from Menu.getApplicationMenu()
 	 */
 	public async refreshMenu(): Promise<void> {
-		if (!isMacintosh) ipcRenderer.invoke('request-application-menu').then(menu => this.updateMenu(menu));
+		if (!isMacintosh) ipcRenderer.invoke('request-application-menu').then((menu: Menu) => this.updateMenu(menu));
 	}
 
 	/**


### PR DESCRIPTION
## The problem
We want to dynamically change if the menu is displayed or not, there was an [option added in v4.1.0](https://github.com/AlexTorresDev/custom-electron-titlebar/pull/175#:~:text=menuOptions.menu%20can%20be%20set%20to%20null%20to%20not%20use%20any%20menu) which did exactly that:
```
titlebar.updateMenu(null);
```
A refactor in a later version broke that functionality.

## The solution
In `updateMenu`, after disposing of the old bar, if there isn't a new bar specified, exit the function
> the fix is one line, the other changes are typescript errors that prevented me from compiling for testing


----

We actually depend on this feature over at https://github.com/th-ch/youtube-music - can you please merge and release a hotfix? @AlexTorresDev 

