### PR TITLE
Remove the `:focus` on the menubar menu button class to fix styling

### DIFF
--- a/static/theme/base.css
+++ b/static/theme/base.css
@@ -250,13 +250,11 @@ body {
   opacity: 0.4;
 }
 
-.cet-menubar .cet-menubar-menu-button:not(.disabled):focus,
 .cet-menubar .cet-menubar-menu-button:not(.disabled):hover,
 .cet-menubar .cet-menubar-menu-button:not(.disabled).open {
   background-color: rgb(255 255 255 / 12%);
 }
 
-.cet-titlebar.light .cet-menubar .cet-menubar-menu-button:not(.disabled):focus,
 .cet-titlebar.light .cet-menubar .cet-menubar-menu-button:not(.disabled):hover,
 .cet-titlebar.light .cet-menubar .cet-menubar-menu-button:not(.disabled).open {
   background-color: rgb(0 0 0 / 12%);


### PR DESCRIPTION
This PR fixes #225 by removing the unnecessary `:focus` CSS selector. I only tested this on Windows.

Before this PR:

![electron-titlebar-before](https://github.com/AlexTorresDev/custom-electron-titlebar/assets/549323/89a05cc0-1f54-4404-9674-85d851f0f000)

After this PR:

![electron-titlebar-after](https://github.com/AlexTorresDev/custom-electron-titlebar/assets/549323/fdf98b5e-e964-4eb0-98ca-79f75216a676)

