### PR TITLE
Fixed: The submenus are not aligned with the title menu #247

### DIFF
--- a/src/menubar/index.ts
+++ b/src/menubar/index.ts
@@ -1004,15 +1004,15 @@ export class MenuBar extends Disposable {
 		const actualMenuIndex = menuIndex >= this.numMenusShown ? MenuBar.OVERFLOW_INDEX : menuIndex
 		const customMenu = actualMenuIndex === MenuBar.OVERFLOW_INDEX ? this.overflowMenu : this.menus[actualMenuIndex]
 
-		if (!customMenu.actions || !customMenu.buttonElement || !customMenu.titleElement) {
+		if (!customMenu.actions || !customMenu.buttonElement) {
 			return
 		}
 
 		const menuHolder = $('.cet-menubar-menu-container', { title: '' })
 		customMenu.buttonElement.classList.add('open')
 
-		const titleBoundingRect = customMenu.titleElement.getBoundingClientRect()
-		const titleBoundingRectZoom = DOM.getDomNodeZoomLevel(customMenu.titleElement)
+		const titleBoundingRect = customMenu.buttonElement.getBoundingClientRect()
+		const titleBoundingRectZoom = DOM.getDomNodeZoomLevel(customMenu.buttonElement)
 
 		if (this.options.compactMode === Direction.Right) {
 			menuHolder.style.top = `${titleBoundingRect.top}px`


### PR DESCRIPTION
Fixed the issue #247 

The original code was getting the bounding box of the Title, so the menu was being aligned with the text and not the actual Menu button, this PR fixes it.

![image](https://github.com/AlexTorresDev/custom-electron-titlebar/assets/16841645/86d32d40-1d38-448c-b5d2-140cc77ad814)
