### PR TITLE
Fixed: Title moves to the left after resizing #246

### DIFF
--- a/src/titlebar/index.ts
+++ b/src/titlebar/index.ts
@@ -440,6 +440,12 @@ export class CustomTitlebar extends ThemeBar {
 		}
 	}
 
+	private canCenterTitle() {
+		const menuBarContainerMargin = 20
+		const menuSpaceLimit = window.innerWidth / 2 - this.menuBarContainer.getBoundingClientRect().right - menuBarContainerMargin
+		return (this.title.getBoundingClientRect().width / 2 <= menuSpaceLimit)
+	}
+
 	/// Public methods
 
 	/**
@@ -540,15 +546,15 @@ export class CustomTitlebar extends ThemeBar {
 
 			if (menuPosition !== 'bottom') {
 				addDisposableListener(window, 'resize', () => {
-					const menuBarContainerMargin = 20
-					const menuSpaceLimit = window.innerWidth / 2 - this.menuBarContainer.getBoundingClientRect().right - menuBarContainerMargin
-					if (this.title.getBoundingClientRect().width / 2 <= menuSpaceLimit) {
+					if (this.canCenterTitle()) {
 						addClass(this.title, 'cet-title-center')
 					} else {
 						removeClass(this.title, 'cet-title-center')
 					}
 				})
-				addClass(this.title, 'cet-title-center')
+				if (this.canCenterTitle()) {
+					addClass(this.title, 'cet-title-center')
+				}
 			}
 
 			if (!isMacintosh && order === 'first-buttons') {

--- a/src/titlebar/index.ts
+++ b/src/titlebar/index.ts
@@ -540,7 +540,9 @@ export class CustomTitlebar extends ThemeBar {
 
 			if (menuPosition !== 'bottom') {
 				addDisposableListener(window, 'resize', () => {
-					if (window.innerWidth >= 1188) {
+					const menuBarContainerMargin = 20
+					const menuSpaceLimit = window.innerWidth / 2 - this.menuBarContainer.getBoundingClientRect().right - menuBarContainerMargin
+					if (this.title.getBoundingClientRect().width / 2 <= menuSpaceLimit) {
 						addClass(this.title, 'cet-title-center')
 					} else {
 						removeClass(this.title, 'cet-title-center')


### PR DESCRIPTION
Fixed the issue #246 by correctly calculating the remaining space for the title based on the MenuContainer right position and the width of the window.

![electron-fixed-title](https://github.com/AlexTorresDev/custom-electron-titlebar/assets/16841645/c607c50a-66a5-4902-b457-6054b213570d)
